### PR TITLE
Adds simplistic, optional cache for the middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ properties:
 | `excludeUrlPattern` | A set of known static file extensions. [Full list.](https://github.com/LasaleFamine/pupperender/blob/master/src/index.js) | RegExp for excluding requests by the path component of the URL. |
 | `timeout` | `11000` | Millisecond timeout for waiting the page to load. Used by Puppeter. See also the [Puppeter waitFor()](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagewaitforselectororfunctionortimeout-options-args) |
 | `debug` | `false` | DEBUG flag to show some logs |
+| `useCache` | `false` | If the puppeterized content should be cached to speed up subsequent requests. |
+| `cacheTTL` | `3600` | Seconds until cached content is disregarded and puppeterized again. Only considered when `useCache` is `true`. |
 
 
 ## License

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ const cache = {};
 module.exports.makeMiddleware = options => {
 	const DEBUG = options.debug;
 	const timeout = options.timeout || 5000; // ms
-        const useCache = !!options.useCache;
+	const useCache = Boolean(options.useCache);
 	const userAgentPattern =
       options.userAgentPattern || new RegExp(botUserAgents.join('|'), 'i');
 	const excludeUrlPattern = options.excludeUrlPattern ||
@@ -78,18 +78,18 @@ module.exports.makeMiddleware = options => {
 
 		const incomingUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
 		logger(DEBUG, `[pupperender middleware] puppeterize url: ${incomingUrl}`);
-		
+
 		if (useCache && cache[incomingUrl]) {
-			logger(DEBUG, `Cache hit for ${incomingUrl}.`)
+			logger(DEBUG, `Cache hit for ${incomingUrl}.`);
 			res.set('Pupperender', 'true');
 			res.send(cache[incomingUrl]);
-			return
+			return;
 		}
-		
+
 		pupperender(incomingUrl, timeout)
 			.then(content => { // eslint-disable-line promise/prefer-await-to-then
 				cache[incomingUrl] = content;
-				logger(DEBUG, `Cache warmed for ${incomingUrl}.`)
+				logger(DEBUG, `Cache warmed for ${incomingUrl}.`);
 				res.set('Pupperender', 'true');
 				res.send(content);
 			})

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ module.exports.makeMiddleware = options => {
 	const DEBUG = options.debug;
 	const timeout = options.timeout || 5000; // ms
 	const useCache = Boolean(options.useCache);
-	const cacheTTL = options.cacheTTL || 3600; // seconds
+	const cacheTTL = (options.cacheTTL || 3600) * 1000; // ms
 	const userAgentPattern =
       options.userAgentPattern || new RegExp(botUserAgents.join('|'), 'i');
 	const excludeUrlPattern = options.excludeUrlPattern ||
@@ -80,9 +80,10 @@ module.exports.makeMiddleware = options => {
 		const incomingUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
 		logger(DEBUG, `[pupperender middleware] puppeterize url: ${incomingUrl}`);
 		if (useCache && cache[incomingUrl] &&
-					(Date.now() - cache[incomingUrl].createdAt) <= cacheTTL * 1000) {
+					Date.now() <= cache[incomingUrl].expiresAt) {
 			logger(DEBUG, `[pupperender middleware] Cache hit for ${incomingUrl}.`);
 			res.set('Pupperender', 'true');
+			res.set('Expires', new Date(cache[incomingUrl].expiresAt).toUTCString());
 			res.send(cache[incomingUrl].data);
 			return;
 		}
@@ -90,7 +91,7 @@ module.exports.makeMiddleware = options => {
 		pupperender(incomingUrl, timeout)
 			.then(content => { // eslint-disable-line promise/prefer-await-to-then
 				cache[incomingUrl] = {
-					createdAt: Date.now(),
+					expiresAt: Date.now() + cacheTTL,
 					data: content
 				};
 				logger(DEBUG, `[pupperender middleware] Cache warmed for ${incomingUrl}.`);

--- a/src/index.js
+++ b/src/index.js
@@ -80,13 +80,16 @@ module.exports.makeMiddleware = options => {
 		logger(DEBUG, `[pupperender middleware] puppeterize url: ${incomingUrl}`);
 		
 		if (useCache && cache[incomingUrl]) {
+			logger(DEBUG, `Cache hit for ${incomingUrl}.`)
 			res.set('Pupperender', 'true');
 			res.send(cache[incomingUrl]);
+			return
 		}
 		
 		pupperender(incomingUrl, timeout)
 			.then(content => { // eslint-disable-line promise/prefer-await-to-then
 				cache[incomingUrl] = content;
+				logger(DEBUG, `Cache warmed for ${incomingUrl}.`)
 				res.set('Pupperender', 'true');
 				res.send(content);
 			})

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,29 @@ test('puppeterize getting a route as bot', async t => {
 	t.true(Boolean(res.get('Pupperender')));
 });
 
+test('puppeterize is being cached if configured', async t => {
+	const appUrl = await listen(makeApp({useCache: true}));
+
+	const res = await get(bot, appUrl, '/foo');
+	t.is(res.status, 200);
+	t.false(Boolean(res.get('Expires')));
+	const cachedRes = await get(bot, appUrl, '/foo');
+	t.is(cachedRes.status, 200);
+	t.true(Boolean(cachedRes.get('Expires')));
+});
+
+test('cache respects cache timeout', async t => {
+	const appUrl = await listen(makeApp({useCache: true, cacheTTL: 1}));
+
+	const res = await get(bot, appUrl, '/foo');
+	t.is(res.status, 200);
+	t.false(Boolean(res.get('Expires')));
+	await new Promise(resolve => setTimeout(resolve, 2000));
+	const cachedRes = await get(bot, appUrl, '/foo');
+	t.is(cachedRes.status, 200);
+	t.false(Boolean(cachedRes.get('Expires')));
+});
+
 test('excludes static file paths by default', async t => {
 	const appUrl = await listen(makeApp({}));
 


### PR DESCRIPTION
The rendering with puppeteer can get quite slow, so I thought it'd be nice to have the possibility to do some simplistic in-memory caching. WDYT?

I'm wondering if there should be a cache timeout where the content is refreshed?